### PR TITLE
Create file only when downloaded, add new mirror & little change for url switch case

### DIFF
--- a/src/api/v2/routes/beatmap/set/download.ts
+++ b/src/api/v2/routes/beatmap/set/download.ts
@@ -46,33 +46,30 @@ export const description: Description = {
 
 
 const name: types = async (beatmapset, file_path, host_name, no_video, callback) => {
-  let url = '';
-
-  switch (host_name) {
-    case 'osu':
-      url = `https://osu.ppy.sh/api/v2/beatmapsets/${beatmapset}/download${no_video ? '?noVideo=1' : ''}`;
-      break;
-
-    case 'chimu':
-      url = `https://chimu.moe/v1/download/${beatmapset}`;
-      break;
-
-    case 'beatconnect':
-      url = `https://beatconnect.io/b/${beatmapset}/`;
-      break;
-
-    case 'sayobot':
-      url = `https://dl.sayobot.cn/beatmaps/download/${no_video ? 'novideo' : 'full'}/${beatmapset}`;
-      break;
-
-    case 'nerinyan':
-      url = `https://api.nerinyan.moe/d/${beatmapset}${no_video ? '?nv=1' : ''}`;
-      break;
-
-    default:
-      url = `https://osu.ppy.sh/api/v2/beatmapsets/${beatmapset}/download${no_video ? '?noVideo=1' : ''}`;
-      break;
-  };
+  const url = (() => {
+    switch (host_name) {
+      case 'osu':
+        return `https://osu.ppy.sh/api/v2/beatmapsets/${beatmapset}/download${no_video ? '?noVideo=1' : ''}`;
+  
+      case 'chimu':
+        return `https://chimu.moe/v1/download/${beatmapset}`;
+  
+      case 'beatconnect':
+        return `https://beatconnect.io/b/${beatmapset}/`;
+  
+      case 'sayobot':
+        return `https://dl.sayobot.cn/beatmaps/download/${no_video ? 'novideo' : 'full'}/${beatmapset}`;
+  
+      case 'nerinyan':
+        return `https://api.nerinyan.moe/d/${beatmapset}${no_video ? '?nv=1' : ''}`;
+      
+      case 'mino':
+        return `https://catboy.best/d/${beatmapset}${no_video ? "n" : ""}`;
+  
+      default:
+        return `https://osu.ppy.sh/api/v2/beatmapsets/${beatmapset}/download${no_video ? '?noVideo=1' : ''}`;
+    };
+  })();
 
   const data = await download(url, file_path, {
     headers: {

--- a/src/types/v2_beatmap_set_download.ts
+++ b/src/types/v2_beatmap_set_download.ts
@@ -26,5 +26,5 @@ export interface types {
    * @param {boolean} no_video Download with or without video
    * @param {Function} callback function which is will be triggered on downloading progress
   */
-  (beatmapset: number, file_path: string, host_name: 'osu' | 'chimu' | 'beatconnect' | 'sayobot' | 'nerinyan' | '' , no_video: boolean, callback?: Function): Promise<string>;
+  (beatmapset: number, file_path: string, host_name: 'osu' | 'chimu' | 'beatconnect' | 'sayobot' | 'nerinyan' | 'mino' | '' , no_video: boolean, callback?: Function): Promise<Boolean>;
 }

--- a/src/types/v2_beatmap_set_download.ts
+++ b/src/types/v2_beatmap_set_download.ts
@@ -26,5 +26,5 @@ export interface types {
    * @param {boolean} no_video Download with or without video
    * @param {Function} callback function which is will be triggered on downloading progress
   */
-  (beatmapset: number, file_path: string, host_name: 'osu' | 'chimu' | 'beatconnect' | 'sayobot' | 'nerinyan' | 'mino' | '' , no_video: boolean, callback?: Function): Promise<Boolean>;
+  (beatmapset: number, file_path: string, host_name: 'osu' | 'chimu' | 'beatconnect' | 'sayobot' | 'nerinyan' | 'mino' | '' , no_video: boolean, callback?: Function): Promise<string>;
 }

--- a/src/utility/request.ts
+++ b/src/utility/request.ts
@@ -116,7 +116,7 @@ export const request = (url: string, { method = "GET", headers, data, params = {
  * @param {string} dest The file destination
  * @returns {Promise<any>} The response
  */
-export const download = (url: string, dest: string, { headers = {}, data, params }: RequestParams = {}, callback?: Function): Promise<Boolean> => {
+export const download = (url: string, dest: string, { headers = {}, data, params }: RequestParams = {}, callback?: Function): Promise<any> => {
   return new Promise((resolve, reject) => {
     if (url.includes('https://osu.ppy.sh/api/v2')) headers['Authorization'] = `Bearer ${auth.cache_v2}`;
 
@@ -135,7 +135,7 @@ export const download = (url: string, dest: string, { headers = {}, data, params
       }
 
       if (response.statusCode === 404) {
-        resolve(false);
+        resolve({ error: 'file unavailable' });
         return;
       }
 
@@ -148,7 +148,7 @@ export const download = (url: string, dest: string, { headers = {}, data, params
   
       file.on('finish', () => {
         file.close();
-        resolve(true);
+        resolve(dest);
       });
 
       if (callback !== undefined) {


### PR DESCRIPTION
I noticed that files are being created even if the download doesn't even start to begin due to the set requested not existing. With that i rather have a true and false boolean when the promise resolves rather than to have a random string to know if the download failed or not since it creates an easier check.
I also added support for another mirror which supports many download regions across the entire world (8 Servers in total).
Last but not least there's also a minor change in the way how the url is being switched which shaves off a few lines.