### PR TITLE
fix: correct scope for lazer login

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -40,7 +40,8 @@ export type auth_scopes = (
   'forum.write' |
   'friends.read' |
   'identify' |
-  'public'
+  'public' |
+  '*'
 )[];
 
 

--- a/utility/auth.ts
+++ b/utility/auth.ts
@@ -104,6 +104,7 @@ export function login<T extends auth_params>(params: auth_params): ResponseLogin
   if (params.type == 'lazer') {
     credentials.login = params.login;
     credentials.password = params.password;
+    credentials.scopes = ["*"];
 
     return lazer_login(params.login, params.password) as ResponseLogin<T['type']>;
   };


### PR DESCRIPTION
when using the login function with type `lazer`, the scope remains `public`, this PR fixes this.