### PR TITLE
(duplicate) fix(types): restrict no_video param to supported hosts

### DIFF
--- a/api/v2/beatmaps_download.ts
+++ b/api/v2/beatmaps_download.ts
@@ -1,4 +1,4 @@
-import { IDefauааltParams } from "../../types";
+import { IDefaultParams } from "../../types";
 import { download } from "../../utility/request";
 import { cache, credentials } from "../../utility/auth";
 import path from "path";
@@ -55,7 +55,7 @@ type params =
     progress_log_fn?: (host: string, progress: number) => void;
   };
 
-  
+
 /**
  * `async` Downloads a beatmap or beatmap set by given ID. (Supports different hosts)
  *

--- a/api/v2/beatmaps_download.ts
+++ b/api/v2/beatmaps_download.ts
@@ -7,7 +7,8 @@ import { handleErrors } from "../../utility/handleErrors";
 import { BeatmapsDownloadResponse } from "../../types/v2/beatmaps_download";
 
 
-type params = 
+
+type params =
   | {
     type: 'difficulty';
     id: number;
@@ -18,42 +19,31 @@ type params =
     overwrite?: boolean;
     progress_log_fn?: (host: string, progress: number) => void;
   }
-  // Both video and no video
-  | {
+  | ({
+    // Both video and no video
+
     type: 'set';
     id: number;
 
-    host: 'osu' | 'nerinyan' | 'sayobot',
+    file_path: string;
+    overwrite?: boolean;
+
+    progress_log_fn?: (host: string, progress: number) => void;
+  } & ({
+    host: 'osu' | 'nerinyan' | 'sayobot';
     no_video?: boolean;
+  } | {
+    // Video only
 
-    file_path: string;
-    overwrite?: boolean;
-    progress_log_fn?: (host: string, progress: number) => void;
-  }
-  // Video only
-  | {
-    type: 'set';
-    id: number;
+    host: 'beatconnect' | 'osu_direct_mirror' | 'ripple' | 'catboy' | 'mino' | 'akatsuki';
+    no_video?: false;
+  } | {
+    // NO video only
 
-    host: 'beatconnect' | 'osu_direct_mirror' | 'ripple' | 'catboy' | 'mino' | 'akatsuki',
-    no_video?: never | false;
-
-    file_path: string;
-    overwrite?: boolean;
-    progress_log_fn?: (host: string, progress: number) => void;
-  }
-  // NO video only
-  | {
-    type: 'set';
-    id: number;
-
-    host: 'gatari',
+    host: 'gatari';
     no_video: true;
+  }));
 
-    file_path: string;
-    overwrite?: boolean;
-    progress_log_fn?: (host: string, progress: number) => void;
-  };
 
 
 /**
@@ -85,7 +75,7 @@ type params =
  * ### Usage Example
  * ```js
  * const { auth, v2, tools } = require('osu-api-extended');
- * 
+ *
  * async function main() {
  *   try {
  *     // only for downloading sets from osu host
@@ -95,14 +85,14 @@ type params =
  *       password: password,
  *       cachedTokenPath: './test.json' // path to the file your auth token will be saved (to prevent osu!api spam)
  *     });
- * 
- * 
+ *
+ *
  *     const progress_update = (...args) => {
  *       console.log(args);
  *     };
  *     const set_id = 320118;
- * 
- * 
+ *
+ *
  *     const result = await v2.beatmaps.download({
  *       type: 'set',
  *       host: 'gatari',
@@ -118,13 +108,13 @@ type params =
  *       file_path: `./cache/${set_id}.osz`,
  *       progress_log_fn: progress_update
  *     });
- * 
+ *
  *     console.log(result);
  *   } catch (error) {
  *     console.log(error);
  *   };
  * };
- * 
+ *
  * main();
  * ```
  *

--- a/api/v2/beatmaps_download.ts
+++ b/api/v2/beatmaps_download.ts
@@ -1,4 +1,4 @@
-import { IDefaultParams } from "../../types";
+import { IDefauааltParams } from "../../types";
 import { download } from "../../utility/request";
 import { cache, credentials } from "../../utility/auth";
 import path from "path";
@@ -7,32 +7,55 @@ import { handleErrors } from "../../utility/handleErrors";
 import { BeatmapsDownloadResponse } from "../../types/v2/beatmaps_download";
 
 
+type params = 
+  | {
+    type: 'difficulty';
+    id: number;
 
-type params = ({
-  type: 'difficulty';
+    host: 'osu' | 'osu_direct_mirror' | 'catboy';
 
-  id: number;
-  host: 'osu' | 'osu_direct_mirror' | 'catboy';
+    file_path: string;
+    overwrite?: boolean;
+    progress_log_fn?: (host: string, progress: number) => void;
+  }
+  // Both video and no video
+  | {
+    type: 'set';
+    id: number;
 
-  file_path: string;
-  overwrite?: boolean;
+    host: 'osu' | 'nerinyan' | 'sayobot',
+    no_video?: boolean;
 
-  progress_log_fn?: (host: string, progress: number) => void;
-} | {
-  type: 'set';
+    file_path: string;
+    overwrite?: boolean;
+    progress_log_fn?: (host: string, progress: number) => void;
+  }
+  // Video only
+  | {
+    type: 'set';
+    id: number;
 
-  id: number;
-  host: 'osu' | 'beatconnect' | 'nerinyan' | 'osu_direct_mirror' | 'sayobot' | 'gatari' | 'ripple' | 'catboy' | 'mino' | 'akatsuki',
+    host: 'beatconnect' | 'osu_direct_mirror' | 'ripple' | 'catboy' | 'mino' | 'akatsuki',
+    no_video?: never | false;
 
-  file_path: string;
-  no_video?: boolean;
-  overwrite?: boolean;
+    file_path: string;
+    overwrite?: boolean;
+    progress_log_fn?: (host: string, progress: number) => void;
+  }
+  // NO video only
+  | {
+    type: 'set';
+    id: number;
 
-  progress_log_fn?: (host: string, progress: number) => void;
-});
+    host: 'gatari',
+    no_video: true;
 
+    file_path: string;
+    overwrite?: boolean;
+    progress_log_fn?: (host: string, progress: number) => void;
+  };
 
-
+  
 /**
  * `async` Downloads a beatmap or beatmap set by given ID. (Supports different hosts)
  *


### PR DESCRIPTION
Previously, the no_video parameter was available for all download hosts, which was confusing since not all mirrors support no-video versions of beatmaps. I refactored the params union in the download function to enforce strict typescript checks based on video availability